### PR TITLE
Removed duplicate default task definition

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,4 @@ namespace :travis do
 end
 
 # The default rake task should just run it all
-task default: %w(travis:ci integration)
-
-# The default rake task should just run it all
 task default: ['style', 'spec', 'integration:vagrant']


### PR DESCRIPTION
:information_desk_person: The default Rake task will have been that which was defined last, so I'm assuming that's the expected behaviour.